### PR TITLE
Add Switch entity for One Time Charge

### DIFF
--- a/custom_components/vicare/switch.py
+++ b/custom_components/vicare/switch.py
@@ -120,7 +120,7 @@ class ViCareSwitch(SwitchEntity):
         self._device_config = device_config
         self._api = api
         self._ignore_update_until = datetime.datetime.utcnow()
-        self._state = None
+        update()
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/vicare/switch.py
+++ b/custom_components/vicare/switch.py
@@ -120,7 +120,7 @@ class ViCareSwitch(SwitchEntity):
         self._device_config = device_config
         self._api = api
         self._ignore_update_until = datetime.datetime.utcnow()
-        update()
+        self.update()
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
Implemented and tested:

Switch entity to enable/disable onetime charge
status will depict whether the onetime charge is on
Note: Enabling/Disabling currently does trigger a scheduled update to the API. However it looks like the return value of the API still shows the old state, making it a bit clumpsy: The switch gets disabled again, and then enabled after the next Poll.

I have not yet found out how to fix this beautifully, but wanted to share the progress.

Missing also a statement by @oischinger whether we should mark the "button" entity as deprecated somehow?

fixes https://github.com/oischinger/ha_vicare/issues/96

+ Did the changes requested by [oischinger](https://github.com/oischinger)